### PR TITLE
FIX: race condition in runzeus.sh when joining an existing cluster

### DIFF
--- a/runzeus.sh
+++ b/runzeus.sh
@@ -93,6 +93,10 @@ then
 	EOF
 
 	if [ -n "$ZEUS_CLUSTER_NAME" ]; then
+		while [ -n "$(curl -k -s -S -o/dev/null https://$ZEUS_CLUSTER_NAME:9090)" ];
+		do
+			sleep 1
+		done
 		sed -i 's/zxtm!cluster=C/zxtm!cluster=S/' /usr/local/zeus/zconfig.txt
 		cat <<-EOF >> /usr/local/zeus/zconfig.txt
 			zlb!admin_hostname=$ZEUS_CLUSTER_NAME
@@ -104,7 +108,13 @@ then
 		EOF
 	fi
 
-	/usr/local/zeus/zxtm/configure --replay-from=/usr/local/zeus/zconfig.txt 
+	/usr/local/zeus/zxtm/configure --noninteractive --noloop --replay-from=/usr/local/zeus/zconfig.txt
+	while [ $? -ne 0 ];
+	do
+		sleep 1
+		/usr/local/zeus/zxtm/configure --noninteractive --noloop --replay-from=/usr/local/zeus/zconfig.txt
+	done
+
 	touch /usr/local/zeus/docker.done
 	rm /usr/local/zeus/zconfig.txt
 


### PR DESCRIPTION
if slave container is started before master one, then slave fails
joining the cluster and hangs because it could not contact master.

2 fixes for this issue:
- wait for the GUI of the master to be available (simple curl in a
  while/sleep loop)
- when the configuration script fails setting up everything, run a
  while/sleep loop to retry configuring the slave every 1s.
